### PR TITLE
make google play framework import more fine grained

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@
 
   <!-- android -->
   <platform name="android">
-    <framework src="com.google.android.gms:play-services:8.3.0+" />
+    <framework src="com.google.android.gms:play-services-fitness:8.3.0+" />
 
     <config-file target="AndroidManifest.xml" parent="/*">
       <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />


### PR DESCRIPTION
since this plugin only requires access to the fitness APIs of google play services, only the fitness section should be marked as a dependency (ref [
Setting Up Google Play Services](https://developers.google.com/android/guides/setup) ). This helps prevent android builds hitting the 65k DEX max method limit build error when this plugin is used alongside other cordova plugins that make use of google play services (ie: push notifications).