### PR TITLE
Use pluginInitialize instead initWithWebView

### DIFF
--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -25,12 +25,8 @@ static NSString *const HKPluginKeyUUID = @"UUID";
 
 @implementation HealthKit
 
-- (CDVPlugin*) initWithWebView:(UIWebView*)theWebView {
-    self = (HealthKit*)[super initWithWebView:theWebView];
-    if (self) {
-        _healthStore = [HKHealthStore new];
-    }
-    return self;
+- (void) pluginInitialize {
+    _healthStore = [HKHealthStore new];
 }
 
 - (void) available:(CDVInvokedUrlCommand*)command {


### PR DESCRIPTION
Because of changes in cordova-ios-4.0

According to https://github.com/apache/cordova-ios/blob/master/guides/API%20changes%20in%204.0.md#upgrade-notes-1 