### PR TITLE
Change play-services dependency for others plugins compatibility

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -58,7 +58,7 @@
 
   <!-- android -->
   <platform name="android">
-    <framework src="com.google.android.gms:play-services-fitness:8.3.0+" />
+    <framework src="com.google.android.gms:play-services-fitness:+" />
 
     <config-file target="AndroidManifest.xml" parent="/*">
       <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />


### PR DESCRIPTION
Use "com.google.android.gms:play-services-fitness:+" as dependency (instead of 8.3.0+) to avoid issues with plugins that uses newer play-services API

I need to use this plugin along with https://github.com/danwilson/google-analytics-plugin.git
Today the play-services dependency for google analytics plugin is 8.4, and using together 8.3 and 8.4 gives compilations errors because of multiple DEX or something like that.

This pull-request resolves the issue and will keep using newer versions, but if google, someday, releases a new major version and there are big changes in the api, it will probably break the plugin.
