### PR TITLE
Add support for item brand names in nutrition data type response

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ value can be of different types, see examples below:
 | steps          | 34                                |
 | distance       | 101.2                             |
 | calories       | 245.3                             |
-| activity       | "walking"  (note: recognized activities and their mapping to Fit / HealthKit equivalents are listed in [this file](activities_map.md)) |
+| activity       | "walking"<br />**Note**: recognized activities and their mapping to Fit / HealthKit equivalents are listed in [this file](activities_map.md) |
 | height         | 185.9                             |
 | weight         | 83.3                              |
 | heart_rate     | 66                                |
 | fat_percentage | 31.2                              |
 | gender         | "male"                            |
 | date_of_birth  | { day: 3, month: 12, year: 1978 } |
-| nutrition      | { item: "cheese", meal_type: "lunch", brand_name: "McDonald's", nutrients: { nutrition.fat.saturated: 11.5, nutrition.calories: 233.1 } } |
+| nutrition      | { item: "cheese", meal_type: "lunch", brand_name: "McDonald's", nutrients: { nutrition.fat.saturated: 11.5, nutrition.calories: 233.1 } }<br />**Note**: `meal_type` and `brand_name` properties are only available on iOS |
 | nutrition.X    | 12.4                              |
 
 ## Methods

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ value can be of different types, see examples below:
 | fat_percentage | 31.2                              |
 | gender         | "male"                            |
 | date_of_birth  | { day: 3, month: 12, year: 1978 } |
-| nutrition      | { item: "cheese", meal_type: "lunch", nutrients: { nutrition.fat.saturated: 11.5, nutrition.calories: 233.1 } } |
+| nutrition      | { item: "cheese", meal_type: "lunch", brand_name: "McDonald's", nutrients: { nutrition.fat.saturated: 11.5, nutrition.calories: 233.1 } } |
 | nutrition.X    | 12.4                              |
 
 ## Methods

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ value can be of different types, see examples below:
 | fat_percentage | 31.2                              |
 | gender         | "male"                            |
 | date_of_birth  | { day: 3, month: 12, year: 1978 } |
-| nutrition      | { item: "cheese", meal_type: "lunch", brand_name: "McDonald's", nutrients: { nutrition.fat.saturated: 11.5, nutrition.calories: 233.1 } }<br />**Note**: `meal_type` and `brand_name` properties are only available on iOS |
+| nutrition      | { item: "cheese", meal_type: "lunch", brand_name: "McDonald's", nutrients: { nutrition.fat.saturated: 11.5, nutrition.calories: 233.1 } }<br />**Note**: the `brand_name` property is only available on iOS |
 | nutrition.X    | 12.4                              |
 
 ## Methods

--- a/www/ios/health.js
+++ b/www/ios/health.js
@@ -431,6 +431,7 @@ Health.prototype.store = function (data, onSuccess, onError) {
     if (!data.metadata) data.metadata = {};
     if (data.value.item) data.metadata.HKFoodType = data.value.item;
     if (data.value.meal_type) data.metadata.HKFoodMeal = data.value.meal_type;
+    if (data.value.brand_name) data.metadata.HKFoodBrandName = data.value.brand_name;
     data.samples = [];
     for (var nutrientName in data.value.nutrients) {
       var unit = units[nutrientName];
@@ -536,6 +537,7 @@ var prepareNutrition = function (data) {
   if (data.sourceBundleId) res.sourceBundleId = data.sourceBundleId;
   if (data.metadata && data.metadata.HKFoodType) res.value.item = data.metadata.HKFoodType;
   if (data.metadata && data.metadata.HKFoodMeal) res.value.meal_type = data.metadata.HKFoodMeal;
+  if (data.metadata && data.metadata.HKFoodBrandName) res.value.brand_name = data.metadata.HKFoodBrandName;
   res.value.nutrients = {};
   for (var j = 0; j < data.samples.length; j++) {
     var sample = data.samples[j];


### PR DESCRIPTION
+ References #25 
+ Added query/store support for `HKFoodBrandName` metadata key in iOS, exposed as `brand_name`
+ README updated to reflect this
+ Minor additional cleanup of README