### PR TITLE
Pass bucket in when querying calories.active

### DIFF
--- a/www/android/health.js
+++ b/www/android/health.js
@@ -31,7 +31,8 @@ Health.prototype.query = function (opts, onSuccess, onError) {
     navigator.health.queryAggregated({
       dataType:'calories.basal',
       endDate: opts.endDate,
-      startDate: opts.startDate
+      startDate: opts.startDate,
+      bucket: opts.bucket
     }, function(data){
       var basal_ms = data.value / (opts.endDate - opts.startDate);
       //now get the total


### PR DESCRIPTION
This PR fixes https://github.com/dariosalvi78/cordova-plugin-health/issues/80. I've tested it on a branch off of 0.7.0, but have not tested it on master.