### PR TITLE
Allow the user to set google services version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ See the [official terms](https://developers.google.com/fit/terms).
 In Cordova:
 
 ```
-cordova plugin add cordova-plugin-health --variable HEALTH_READ_PERMISSION='App needs read access' --variable HEALTH_WRITE_PERMISSION='App needs write access'
+cordova plugin add cordova-plugin-health --variable HEALTH_READ_PERMISSION='App needs read access' --variable HEALTH_WRITE_PERMISSION='App needs write access' --variable GMS_VERSION='11.0.1'
 ```
 
 `HEALTH_READ_PERMISSION` and `HEALTH_WRITE_PERMISSION` are shown when the app tries to grant access to data in HealthKit.
+
+`GMS_VERSION` allow you to override the google services version.
 
 Phonegap Build `config.xml`:
 
@@ -33,6 +35,7 @@ Phonegap Build `config.xml`:
 <plugin name="cordova-plugin-health" source="npm">
   <variable name="HEALTH_READ_PERMISSION" value="App needs read access"/>
   <variable name="HEALTH_WRITE_PERMISSION" value="App needs write access"/>
+  <variable name="GMS_VERSION" value="11.0.1"/>
 </plugin>
 
 <!-- Only if iOS -->
@@ -78,7 +81,7 @@ This is known to happen when using the Ionic Package cloud service.
 * If you haven't configured the APIs correctly, particularly the OAuth requirements, you are likely to get 'User cancelled the dialog' as an error message, particularly this can happen if you mismatch the signing certificate and SHA-1 fingerprint.
 * You can use the Google Fitness API even if the user doesn't have Google Fit installed, but there has to be some other fitness app putting data into the Fitness API otherwise your queries will always be empty. See the [the original documentation](https://developers.google.com/fit/overview).
 * If you are planning to use [health data types](https://developers.google.com/android/reference/com/google/android/gms/fitness/data/HealthDataTypes) in Google Fit, be aware that you are always able to read them, but if you want write access [you need to ask permission to Google](https://developers.google.com/fit/android/data-types#restricted_data_types)
-* This plugin is set to use the latest version of the Google Play Services API (`<framework src="com.google.android.gms:play-services-fitness:+" />`). This is done to likely guarantee the compatibility with other plugins using Google Play Services, but bear in mind that other plugins may be using a different version of the API. If you run into an issue, check the generated gradle file (build.gradle) under `dependencies` between `// SUB-PROJECT DEPENDENCIES START` and `// SUB-PROJECT DEPENDENCIES END` and make sure that all versions of the `com.google.android.gms:play-services-xxxx` are the same.
+* This plugin is set to uou can change that by setting the `GMS_VERSION` variable in `config.xml`.
 
 ## Supported data types
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This is known to happen when using the Ionic Package cloud service.
 * If you haven't configured the APIs correctly, particularly the OAuth requirements, you are likely to get 'User cancelled the dialog' as an error message, particularly this can happen if you mismatch the signing certificate and SHA-1 fingerprint.
 * You can use the Google Fitness API even if the user doesn't have Google Fit installed, but there has to be some other fitness app putting data into the Fitness API otherwise your queries will always be empty. See the [the original documentation](https://developers.google.com/fit/overview).
 * If you are planning to use [health data types](https://developers.google.com/android/reference/com/google/android/gms/fitness/data/HealthDataTypes) in Google Fit, be aware that you are always able to read them, but if you want write access [you need to ask permission to Google](https://developers.google.com/fit/android/data-types#restricted_data_types)
-* This plugin is set to uou can change that by setting the `GMS_VERSION` variable in `config.xml`.
+* You can change which google services version this plugin uses by setting the `GMS_VERSION` variable in `config.xml`. By default it will use the version `16.0.1`. From version 15 [you don't have to use the same google services version](https://developers.google.com/android/guides/versioning) accross all your cordova plugins. You can track google services releases [here](https://developers.google.com/android/guides/releases). 
 
 ## Supported data types
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the [official terms](https://developers.google.com/fit/terms).
 In Cordova:
 
 ```
-cordova plugin add cordova-plugin-health --variable HEALTH_READ_PERMISSION='App needs read access' --variable HEALTH_WRITE_PERMISSION='App needs write access' --variable GMS_VERSION='11.0.1'
+cordova plugin add cordova-plugin-health --variable HEALTH_READ_PERMISSION='App needs read access' --variable HEALTH_WRITE_PERMISSION='App needs write access'
 ```
 
 `HEALTH_READ_PERMISSION` and `HEALTH_WRITE_PERMISSION` are shown when the app tries to grant access to data in HealthKit.
@@ -35,7 +35,7 @@ Phonegap Build `config.xml`:
 <plugin name="cordova-plugin-health" source="npm">
   <variable name="HEALTH_READ_PERMISSION" value="App needs read access"/>
   <variable name="HEALTH_WRITE_PERMISSION" value="App needs write access"/>
-  <variable name="GMS_VERSION" value="11.0.1"/>
+  <variable name="GMS_VERSION" value="16.0.1"/>
 </plugin>
 
 <!-- Only if iOS -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -79,7 +79,7 @@
   <!-- android -->
   <platform name="android">
     <framework src="com.google.android.gms:play-services-fitness:$GMS_VERSION" />
-    <preference name="GMS_VERSION" default="11.0.1"/>
+    <preference name="GMS_VERSION" default="16.0.1"/>
 
     <config-file target="AndroidManifest.xml" parent="/*">
       <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -78,7 +78,8 @@
 
   <!-- android -->
   <platform name="android">
-    <framework src="com.google.android.gms:play-services-fitness:+" />
+    <framework src="com.google.android.gms:play-services-fitness:$GMS_VERSION" />
+    <preference name="GMS_VERSION" default="11.0.1"/>
 
     <config-file target="AndroidManifest.xml" parent="/*">
       <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />


### PR DESCRIPTION
Right now I have the following error:
```shell
A problem occurred evaluating project ':app'.
> Failed to apply plugin [class 'com.google.gms.googleservices.GoogleServicesPlugin']
   > For input string: "+"
```

With this change, a user can now override the used google services version by setting the `GMS_VERSION` in `config.xml`

Inspired from: [cordova-plugin-google-analytics](https://github.com/danwilson/google-analytics-plugin/blob/1bd62ad1a49183bd839dadcacfcea22cf11fe99b/plugin.xml#L55)