### PR TITLE
Android allow longer duration when querying without bucket

### DIFF
--- a/src/android/HealthPlugin.java
+++ b/src/android/HealthPlugin.java
@@ -1112,7 +1112,6 @@ public class HealthPlugin extends CordovaPlugin {
 
         DataReadRequest.Builder builder = new DataReadRequest.Builder();
         builder.setTimeRange(st, et, TimeUnit.MILLISECONDS);
-        int allms = (int) (et - st);
 
         if (datatype.equalsIgnoreCase("steps")) {
             if (args.getJSONObject(0).has("filtered") && args.getJSONObject(0).getBoolean("filtered")) {
@@ -1157,7 +1156,12 @@ public class HealthPlugin extends CordovaPlugin {
             if (datatype.equalsIgnoreCase("activity")) {
                 builder.bucketByActivityType(1, TimeUnit.MILLISECONDS);
             } else {
-                builder.bucketByTime(allms, TimeUnit.MILLISECONDS);
+                long allms = et - st;
+                if (allms <= Integer.MAX_VALUE) {
+                    builder.bucketByTime((int)allms, TimeUnit.MILLISECONDS);
+                } else {
+                    builder.bucketByTime((int)(allms/1000), TimeUnit.SECONDS);
+                }
             }
         }
 


### PR DESCRIPTION
When executing queryAggregated without a bucket the maximum duration is 2147483647 ms (+/- 25 days) due to the maximum size of an integer.

This change will run the query with duration in seconds if the duration is larger than 2147483647 ms allowing for a maximum of 2147483647 seconds (+/- 68 year). 

It does loose a bit of precision but that's acceptable.