### PR TITLE
remove annotiations which fail the build process in Cordova 9

### DIFF
--- a/src/android/HealthPlugin.java
+++ b/src/android/HealthPlugin.java
@@ -7,7 +7,6 @@ import android.content.IntentSender;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.google.android.gms.common.ConnectionResult;
@@ -426,7 +425,7 @@ public class HealthPlugin extends CordovaPlugin {
         if (mClient != null && mClient.isConnected()) {
             Fitness.ConfigApi.disableFit(mClient).setResultCallback(new ResultCallback<Status>() {
                 @Override
-                public void onResult(@NonNull Status status) {
+                public void onResult(Status status) {
                     if (status.isSuccess()) {
                         mClient.disconnect();
                         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));


### PR DESCRIPTION
Hi,
I've been trying out the current master of `cordova-android` and noticed that the build fails because the annotations package isn't included by default anymore. Since it's just used once and not really necessary, I'd suggest to simply remove it. Also works with Capacitor 2.0 this way.