### PR TITLE
Update Google Play Service API versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Phonegap Build `config.xml`:
 <plugin name="cordova-plugin-health" source="npm">
   <variable name="HEALTH_READ_PERMISSION" value="App needs read access"/>
   <variable name="HEALTH_WRITE_PERMISSION" value="App needs write access"/>
-  <variable name="PLAY_AUTH_VERSION" value="18.1.0"/>
-  <variable name="FIT_API_VERSION" value="19.0.0"/>
+  <variable name="PLAY_AUTH_VERSION" value="19.0.0"/>
+  <variable name="FIT_API_VERSION" value="20.0.0"/>
 </plugin>
 
 <!-- Only if iOS -->


### PR DESCRIPTION
In 2.0.1 the GMS_VERSION (16.0.1) variable was replaced by PLAY_AUTH_VERSION (19.0.0) and FIT_API_VERSION (20.0.0). The readme should use the same default values used on plugin.xml to avoid confusion.

See https://github.com/dariosalvi78/cordova-plugin-health/compare/2.0.0...2.0.1 