### PR TITLE
Update activities mapping with latest types available in iOS

### DIFF
--- a/activities_map.md
+++ b/activities_map.md
@@ -29,10 +29,10 @@ This means that, for example, if you try to save "aerobics" in an iOS applicatio
 |	crossfit	|	CROSSFIT	|	HKWorkoutActivityTypeCrossTraining	|
 |	curling	|	CURLING	|	HKWorkoutActivityTypeCurling	|
 |	dancing	|	DANCING	|	HKWorkoutActivityTypeCardioDance	|
-| dancing.social | NA |
+| dancing.social | NA | HKWorkoutActivityTypeSocialDance |
 | disc_sports | NA | HKWorkoutActivityTypeDiscSports |
 |	diving	|	DIVING	|	HKWorkoutActivityTypeWaterSports	|
-|	elevator	|	ELEVATOR	|	NA | HKWorkoutActivityTypeSocialDance |
+|	elevator	|	ELEVATOR	|	NA	|
 |	elliptical	|	ELLIPTICAL	|	HKWorkoutActivityTypeElliptical	|
 |	ergometer	|	ERGOMETER	|	NA	|
 |	escalator	|	ESCALATOR	|	NA	|
@@ -126,6 +126,7 @@ This means that, for example, if you try to save "aerobics" in an iOS applicatio
 |	swimming.pool	|	SWIMMING_OPEN_WATER	|	HKWorkoutActivityTypeSwimming	|
 |	swimming.open_water	|	SWIMMING_POOL	|	HKWorkoutActivityTypeSwimming	|
 |	table_tennis	|	TABLE_TENNIS	|	HKWorkoutActivityTypeTableTennis	|
+| tai_chi | NA | HKWorkoutActivityTypeTaiChi |
 |	team_sports	|	TEAM_SPORTS	|	NA	|
 |	tennis	|	TENNIS	|	HKWorkoutActivityTypeTennis	|
 |	tilting	|	TILTING	|	NA	|

--- a/activities_map.md
+++ b/activities_map.md
@@ -1,3 +1,5 @@
+# Activities mapping
+
 "NA" is automatically converted "other".
 This means that, for example, if you try to save "aerobics" in an iOS application, you will get back "other" when querying.
 
@@ -11,7 +13,7 @@ This means that, for example, if you try to save "aerobics" in an iOS applicatio
 |	basketball	|	BASKETBALL	|	HKWorkoutActivityTypeBasketball	|
 |	biathlon	|	BIATHLON	|	NA	|
 |	biking	|	BIKING	|	HKWorkoutActivityTypeCycling	|
-|	biking.hand	|	BIKING_HAND	|	HKWorkoutActivityTypeCycling	|
+|	biking.hand	|	BIKING_HAND	|	HKWorkoutActivityTypeHandCycling	|
 |	biking.mountain	|	BIKING_MOUNTAIN	|	HKWorkoutActivityTypeCycling	|
 |	biking.road	|	BIKING_ROAD	|	HKWorkoutActivityTypeCycling	|
 |	biking.spinning	|	BIKING_SPINNING	|	HKWorkoutActivityTypeCycling	|
@@ -22,16 +24,20 @@ This means that, for example, if you try to save "aerobics" in an iOS applicatio
 |	calisthenics	|	CALISTHENICS	|	NA	|
 |	circuit_training	|	CIRCUIT_TRAINING	|	NA	|
 |	cricket	|	CRICKET	|	HKWorkoutActivityTypeCricket	|
+| cooldown | NA | HKWorkoutActivityTypeCooldown |
 |	core_training	|	STRENGTH_TRAINING	|	HKWorkoutActivityTypeCoreTraining	|
 |	crossfit	|	CROSSFIT	|	HKWorkoutActivityTypeCrossTraining	|
 |	curling	|	CURLING	|	HKWorkoutActivityTypeCurling	|
-|	dancing	|	DANCING	|	HKWorkoutActivityTypeDance	|
+|	dancing	|	DANCING	|	HKWorkoutActivityTypeCardioDance	|
+| dancing.social | NA |
+| disc_sports | NA | HKWorkoutActivityTypeDiscSports |
 |	diving	|	DIVING	|	HKWorkoutActivityTypeWaterSports	|
-|	elevator	|	ELEVATOR	|	NA	|
+|	elevator	|	ELEVATOR	|	NA | HKWorkoutActivityTypeSocialDance |
 |	elliptical	|	ELLIPTICAL	|	HKWorkoutActivityTypeElliptical	|
 |	ergometer	|	ERGOMETER	|	NA	|
 |	escalator	|	ESCALATOR	|	NA	|
 |	fencing	|	FENCING	|	HKWorkoutActivityTypeFencing	|
+| fitness_gaming | NA | HKWorkoutActivityTypeFitnessGaming |
 |	fishing	|	NA	|	HKWorkoutActivityTypeFishing	|
 | flexibility | GYMNASTICS | HKWorkoutActivityTypeFlexibility |
 |	football.american	|	FOOTBALL_AMERICAN	|	KWorkoutActivityTypeAmericanFootball	|
@@ -63,13 +69,14 @@ This means that, for example, if you try to save "aerobics" in an iOS applicatio
 |	meditation	|	MEDITATION	|	HKWorkoutActivityTypeMindAndBody	|
 |	martial_arts.mixed	|	MIXED_MARTIAL_ARTS	|	HKWorkoutActivityTypeMartialArts	|
 |	on_foot	|	ON_FOOT	|	NA	|
-|	mixed_metabolic_cardio	|	NA	|	HKWorkoutActivityTypeMixedMetabolicCardioTraining	|
+|	mixed_metabolic_cardio	|	NA	|	HKWorkoutActivityTypeMixedCardio	|
 |	other	|	OTHER	|	HKWorkoutActivityTypeOther	|
 |	p90x	|	P90X	|	NA	|
 |	paddle_sports	|	NA	|	HKWorkoutActivityTypePaddleSports	|
 |	paragliding	|	PARAGLIDING	|	NA	|
 |	pilates	|	PILATES	|	HKWorkoutActivityTypePilates	|
 |	play	|	NA	|	HKWorkoutActivityTypePlay	|
+| pickleball | NA | HKWorkoutActivityTypePickleball |
 |	polo	|	POLO	|	NA	|
 |	preparation_and_recovery	|	NA	|	HKWorkoutActivityTypePreparationAndRecovery	|
 |	racquetball	|	RACQUETBALL	|	HKWorkoutActivityTypeRacquetball	|

--- a/src/ios/WorkoutActivityConversion.m
+++ b/src/ios/WorkoutActivityConversion.m
@@ -20,11 +20,15 @@
 
     case HKWorkoutActivityTypeCycling:  return @"biking";
 
+    case HKWorkoutActivityTypeHandCycling:  return @"biking.hand";
+
     case HKWorkoutActivityTypeBowling:  return @"bowling";
 
     case HKWorkoutActivityTypeBoxing: return @"boxing";
 
     case HKWorkoutActivityTypeCricket:  return @"cricket";
+
+    case HKWorkoutActivityTypeCooldown: return @"cooldown";
 
     case HKWorkoutActivityTypeCoreTraining:  return @"core_training";
 
@@ -34,13 +38,19 @@
 
     case HKWorkoutActivityTypeDance:  return @"dancing";
 
-    case HKWorkoutActivityTypeDanceInspiredTraining:  return @"dancing";
+    case HKWorkoutActivityTypeCardioDance:  return @"dancing";
+
+    case HKWorkoutActivityTypeSocialDance: return @"dancing.social";
+
+    case HKWorkoutActivityTypeDiscSports: return @"disc_sports";
 
     case HKWorkoutActivityTypeElliptical:  return @"elliptical";
 
     case HKWorkoutActivityTypeFencing:  return @"fencing";
 
     case HKWorkoutActivityTypeFishing:  return @"fishing";
+
+    case HKWorkoutActivityTypeFitnessGaming: return @"fitness_gaming";
 
     case HKWorkoutActivityTypeFlexibility:  return @"flexibility";
 
@@ -78,13 +88,15 @@
 
     case HKWorkoutActivityTypeMindAndBody:  return @"meditation";
 
-    case HKWorkoutActivityTypeMixedMetabolicCardioTraining:  return @"mixed_metabolic_cardio";
+    case HKWorkoutActivityTypeMixedCardio:  return @"mixed_metabolic_cardio";
 
     case HKWorkoutActivityTypeOther:  return @"other";
 
     case HKWorkoutActivityTypePaddleSports:  return @"paddle_sports";
 
     case HKWorkoutActivityTypePlay:  return @"play";
+
+    case HKWorkoutActivityTypePickleball: return @"pickleball";
 
     case HKWorkoutActivityTypePilates:  return @"pilates";
 
@@ -174,9 +186,9 @@
 
   } else if ([which isEqualToString:@"barre"]) { return HKWorkoutActivityTypeBarre;
 
-  }else if ([which isEqualToString:@"biking"]) { return HKWorkoutActivityTypeCycling;
+  } else if ([which isEqualToString:@"biking"]) { return HKWorkoutActivityTypeCycling;
 
-  } else if ([which isEqualToString:@"biking.hand"]) { return HKWorkoutActivityTypeCycling;
+  } else if ([which isEqualToString:@"biking.hand"]) { return HKWorkoutActivityTypeHandCycling;
 
   } else if ([which isEqualToString:@"biking.mountain"]) { return HKWorkoutActivityTypeCycling;
 
@@ -194,19 +206,40 @@
 
   } else if ([which isEqualToString:@"cricket"]) { return HKWorkoutActivityTypeCricket;
 
+  } else if ([which isEqualToString:@"cooldown"]) { if (@available(iOS 14.0, *)) {
+      return HKWorkoutActivityTypeCooldown;
+    }
+
   } else if ([which isEqualToString:@"core_training"]) { return HKWorkoutActivityTypeCoreTraining;
 
-  }else if ([which isEqualToString:@"crossfit"]) { return HKWorkoutActivityTypeCrossTraining;
+  } else if ([which isEqualToString:@"crossfit"]) { return HKWorkoutActivityTypeCrossTraining;
 
   } else if ([which isEqualToString:@"curling"]) { return HKWorkoutActivityTypeCurling;
 
-  } else if ([which isEqualToString:@"dancing"]) { return HKWorkoutActivityTypeDance;
+  } else if ([which isEqualToString:@"dancing"]) {
+    if (@available(iOS 14.0, *)) {
+      return HKWorkoutActivityTypeCardioDance;
+    }
+    return HKWorkoutActivityTypeDance;
 
+  } else if ([which isEqualToString:@"dancing.social"]) {
+    if (@available(iOS 14.0, *)) {
+      return HKWorkoutActivityTypeSocialDance;
+    }
+    return HKWorkoutActivityTypeDance;
+
+  } else if ([which isEqualToString:@"disc_sports"]) { if (@available(iOS 13.0, *)) {
+      return HKWorkoutActivityTypeDiscSports;
+    }
   } else if ([which isEqualToString:@"diving"]) { return HKWorkoutActivityTypeWaterSports;
 
   } else if ([which isEqualToString:@"elliptical"]) { return HKWorkoutActivityTypeElliptical;
 
   } else if ([which isEqualToString:@"fencing"]) { return HKWorkoutActivityTypeFencing;
+
+  } else if ([which isEqualToString:@"fitness_gaming"]) { if (@available(iOS 13.0, *)) {
+      return HKWorkoutActivityTypeFitnessGaming;
+  }
 
   } else if ([which isEqualToString:@"fishing"]) { return HKWorkoutActivityTypeFishing;
 
@@ -254,13 +287,17 @@
 
   } else if ([which isEqualToString:@"martial_arts.mixed"]) { return HKWorkoutActivityTypeMartialArts;
 
-  } else if ([which isEqualToString:@"mixed_metabolic_cardio"]) { return HKWorkoutActivityTypeMixedMetabolicCardioTraining;
+  } else if ([which isEqualToString:@"mixed_metabolic_cardio"]) { return HKWorkoutActivityTypeMixedCardio;
 
   } else if ([which isEqualToString:@"other"]) { return HKWorkoutActivityTypeOther;
 
   } else if ([which isEqualToString:@"paddle_sports"]) { return HKWorkoutActivityTypePaddleSports;
 
   } else if ([which isEqualToString:@"play"]) { return HKWorkoutActivityTypePlay;
+
+  } else if ([which isEqualToString:@"pickleball"]) { if (@available(iOS 14.0, *)) {
+      return HKWorkoutActivityTypePickleball;
+  }
 
   } else if ([which isEqualToString:@"pilates"]) { return HKWorkoutActivityTypePilates;
 
@@ -387,10 +424,10 @@
   } else if ([which isEqualToString:@"wrestling"]) { return HKWorkoutActivityTypeWrestling;
 
   } else if ([which isEqualToString:@"yoga"]) { return HKWorkoutActivityTypeYoga;
-
-  } else {
-    return HKWorkoutActivityTypeOther;
   }
+
+  // When no match is available, return other as the result
+  return HKWorkoutActivityTypeOther;
 }
 
 @end

--- a/src/ios/WorkoutActivityConversion.m
+++ b/src/ios/WorkoutActivityConversion.m
@@ -142,6 +142,8 @@
 
     case HKWorkoutActivityTypeTableTennis:  return @"table_tennis";
 
+    case HKWorkoutActivityTypeTaiChi: return @"tai_chi";
+
     case HKWorkoutActivityTypeTennis:  return @"tennis";
 
     case HKWorkoutActivityTypeTrackAndField:  return @"track_and_field";
@@ -380,6 +382,8 @@
   } else if ([which isEqualToString:@"swimming.open_water"]) { return HKWorkoutActivityTypeSwimming;
 
   } else if ([which isEqualToString:@"table_tennis"]) { return HKWorkoutActivityTypeTableTennis;
+
+  } else if ([which isEqualToString:@"tai_chi"]) { return HKWorkoutActivityTypeTaiChi;
 
   } else if ([which isEqualToString:@"tennis"]) { return HKWorkoutActivityTypeTennis;
 


### PR DESCRIPTION
This PR proposes an update to the activities mapping with new activity types added in latest version of [iOS](https://developer.apple.com/documentation/healthkit/hkworkoutactivitytype?language=objc), as well as fixing deprecation warnings as suggested.

New type implemented only for HealthKit: 
- `cooldown`
- `dancing.social`
- `disc_sports`
- `fitness_gaming`
- `pickleball`
- `tai_chi`
