### PR TITLE
Fix workout energy value formatting when it is >= 1000kcal [iOS]

### DIFF
--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -727,7 +727,7 @@ static NSString *const HKPluginKeyUUID = @"UUID";
                                                                                             quantity:nrOfDistanceUnits
                                                                                             startDate:startDate
                                                                                                 endDate:endDate];
-                        } else {      
+                        } else {
                             sampleActivity = [HKQuantitySample quantitySampleWithType:[HKQuantityType quantityTypeForIdentifier:
                                             HKQuantityTypeIdentifierDistanceWalkingRunning]
                                                                                             quantity:nrOfDistanceUnits
@@ -817,10 +817,9 @@ static NSString *const HKPluginKeyUUID = @"UUID";
                         double miles = [workout.totalDistance doubleValueForUnit:[HKUnit meterUnit]];
                         NSString *milesString = [NSString stringWithFormat:@"%ld", (long) miles];
 
-                        NSEnergyFormatter *energyFormatter = [NSEnergyFormatter new];
-                        energyFormatter.forFoodEnergyUse = NO;
+                        // Parse totalEnergyBurned in kilocalories
                         double cals = [workout.totalEnergyBurned doubleValueForUnit:[HKUnit kilocalorieUnit]];
-                        NSString *calories = [energyFormatter stringFromValue:cals unit:[HKUnit kilocalorieUnit]];
+                        NSString *calories = [[NSNumber numberWithDouble:cals] stringValue];
 
                         NSMutableDictionary *entry = [
                                 @{
@@ -1515,7 +1514,7 @@ static NSString *const HKPluginKeyUUID = @"UUID";
 
     // NSPredicate *predicate = [HKQuery predicateForSamplesWithStartDate:startDate endDate:endDate options:HKQueryOptionStrictStartDate];
     NSPredicate *predicate = nil;
-    
+
     BOOL filtered = (args[@"filtered"] != nil && [args[@"filtered"] boolValue]);
     if (filtered) {
         predicate = [NSPredicate predicateWithFormat:@"metadata.%K != YES", HKMetadataKeyWasUserEntered];

--- a/www/ios/health.js
+++ b/www/ios/health.js
@@ -231,8 +231,8 @@ Health.prototype.query = function (opts, onSuccess, onError) {
         if ((res.startDate >= opts.startDate) && (res.endDate <= opts.endDate)) {
           res.value = data[i].activityType;
           res.unit = 'activityType';
-          if (data[i].energy) res.calories = parseInt(data[i].energy.slice(0, -2)); // remove the ending J
-          if (data[i].distance)  res.distance = parseInt(data[i].distance);
+          if (data[i].energy) res.calories = parseInt(data[i].energy);
+          if (data[i].distance) res.distance = parseInt(data[i].distance);
           res.sourceName = data[i].sourceName;
           res.sourceBundleId = data[i].sourceBundleId;
           result.push(res);


### PR DESCRIPTION
`iOS only`: When a client app uses the `query` to query `workouts` in a range of dates, the workouts that have a `workout.totalEnergyBurned` equal or greater than `1000kcal`, the plugin parses it and the result is `1` kcal.
The main reason is that values above `1000` are formatted in a string value as `1.500`, when calling parseInt, it results in `1`.

This PR proposes a fix for that bug by changing the native formatting. Instead of using `NSEnergyFormatter` that appends the unit to the calories value, now it uses a more simpler approach: the double value formatted as string. This is done in this way since the JavaScript part removes the value units and just keeps the calories value. So with this approach we are just sending the value with no units. But the value represents kcal.