### PR TITLE
Filter to only the supported data types

### DIFF
--- a/www/android/health.js
+++ b/www/android/health.js
@@ -2,7 +2,44 @@ var exec = require("cordova/exec");
 
 var Health = function () {
   this.name = "health";
+  this.supported_queries = new Set(["steps", "calories", "calories.basal", "activity",
+                            "height", "weight", "heart_rate", "fat_percentage",
+                            "distance", "oxygen_saturation", "blood_glucose",
+                            "blood_pressure", "sleep", "nutrition.calories",
+                            "nutrition.fat.total", "nutrition.fat.saturated",
+                            "nutrition.fat.unsaturated","nutrition.fat.polyunsaturated",
+                            "nutrition.fat.monounsaturated", "nutrition.fat.trans",
+                            "nutrition.cholesterol", "nutrition.sodium",
+                            "nutrition.potassium", "nutrition.carbs.total",
+                            "nutrition.dietary_fiber", "nutrition.sugar", "nutrition.water",
+                            "nutrition.protein", "nutrition.vitamin_a", "nutrition",
+                            "nutrition.vitamin_c", "nutrition.calcium", "nutrition.iron"]);
 };
+
+Health.prototype.filter_datatypes = function(datatypes){
+  var new_data_type = [];
+  for(var i=0; i<datatypes.length; i++){
+    if (typeof(datatypes[i]) == "object"){
+      var readOnlyDtypes = datatypes[i]["read"];
+      var writeOnlyDtypes = datatypes[i]["write"];
+      var newWriteOnlyDtypes = [];
+      var newReadOnlyDtypes = [];
+      if(!!readOnlyDtypes){
+        newReadOnlyDtypes = this.filter_datatypes(readOnlyDtypes);
+      }
+      if(!!writeOnlyDtypes){
+        newWriteOnlyDtypes = this.filter_datatypes(writeOnlyDtypes);
+      }
+      new_data_type.push({"read" : newReadOnlyDtypes, "write" : newWriteOnlyDtypes});
+    }
+    else {
+      if (this.supported_queries.has(datatypes[i])){
+        new_data_type.push(datatypes[i]);
+      }
+    }
+  }
+  return new_data_type;
+}
 
 Health.prototype.isAvailable = function (onSuccess, onError) {
   exec(onSuccess, onError, "health", "isAvailable", []);
@@ -17,7 +54,7 @@ Health.prototype.promptInstallFit = function (onSuccess, onError) {
 };
 
 Health.prototype.requestAuthorization = function (datatypes, onSuccess, onError) {
-  exec(onSuccess, onError, "health", "requestAuthorization", datatypes);
+  exec(onSuccess, onError, "health", "requestAuthorization", this.filter_datatypes(datatypes));
 };
 
 Health.prototype.isAuthorized = function (datatypes, onSuccess, onError) {


### PR DESCRIPTION
I was getting the following logged in the console-- and a failure to authenticate because of it: 

```
Attempt to invoke virtual method 'java.lang.String com.google.android.gms.fitness.data.DataType.zzk()' on a null object reference
```
I'm writing an app that would like to pull from the bigger set of datatypes that healthkit has to offer, and I think the Google Fit part of this library should validate that it's only trying to authenticate for those supported types... 

NOTE: You can still try to query those datatypes without a problem -- the problem was only in authenticate. 

Sorry if this isn't the best way... I can think harder about it if you think it's worth it. 