### PR TITLE
Added null check for err and err.getCause() with addOnFailureListener

### DIFF
--- a/src/android/HealthPlugin.java
+++ b/src/android/HealthPlugin.java
@@ -346,8 +346,14 @@ public class HealthPlugin extends CordovaPlugin {
           callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
         })
         .addOnFailureListener(err -> {
-          err.getCause().printStackTrace();
-          callbackContext.error("cannot disconnect," + err.getMessage());
+          String message = "";
+          if (err != null) {
+            message = err.getMessage();
+            if (err.getCause() != null) {
+              err.getCause().printStackTrace();
+            }
+          }
+          callbackContext.error("cannot disconnect," + message);
         });
     }
   }
@@ -1461,8 +1467,14 @@ public class HealthPlugin extends CordovaPlugin {
         callbackContext.success();
       })
       .addOnFailureListener(err -> {
-        err.getCause().printStackTrace();
-        callbackContext.error(err.getMessage());
+          String message = "";
+          if (err != null) {
+            message = err.getMessage();
+            if (err.getCause() != null) {
+              err.getCause().printStackTrace();
+            }
+          }
+          callbackContext.error(message);
       });
   }
 
@@ -1501,8 +1513,14 @@ public class HealthPlugin extends CordovaPlugin {
         callbackContext.success();
       })
       .addOnFailureListener(err -> {
-        err.getCause().printStackTrace();
-        callbackContext.error(err.getMessage());
+        String message = "";
+        if (err != null) {
+          message = err.getMessage();
+          if (err.getCause() != null) {
+            err.getCause().printStackTrace();
+          }
+        }
+        callbackContext.error(message);
       });
   }
 }


### PR DESCRIPTION
fixed #255

I also put a null check in err.getMessage() just in case

Confirmed that an error is returned to javascript in each function
- store
`VM535:9 4: The user must be signed in to make this API call.
`
- delete
`VM729:14 4: The user must be signed in to make this API call.
`
- disconnect
`VM561:4 cannot disconnect,4: The user must be signed in to make this API call.`