### PR TITLE
Add support for other sleep states introduces with WatchOS 9

### DIFF
--- a/activities_map.md
+++ b/activities_map.md
@@ -103,9 +103,9 @@ This means that, for example, if you try to save "aerobics" in an iOS applicatio
 |	skiing.roller	|	SKIING_ROLLER	|	HKWorkoutActivityTypeSnowSports	|
 |	sledding	|	SLEDDING	|	HKWorkoutActivityTypeSnowSports	|
 |	sleep	|	SLEEP	|	HKCategoryValueSleepAnalysisAsleep	|
-|	sleep.light	|	SLEEP_LIGHT	|	HKCategoryValueSleepAnalysisAsleep	|
-|	sleep.deep	|	SLEEP_DEEP	|	HKCategoryValueSleepAnalysisAsleep	|
-|	sleep.rem	|	SLEEP_REM	|	HKCategoryValueSleepAnalysisAsleep	|
+|	sleep.light	|	SLEEP_LIGHT	| 	HKCategoryValueSleepAnalysisAsleepCore |
+|	sleep.deep	|	SLEEP_DEEP	| 	HKCategoryValueSleepAnalysisAsleepDeep |
+|	sleep.rem	|	SLEEP_REM	| 	HKCategoryValueSleepAnalysisAsleepREM |
 |	sleep.inBed	|	AWAKE	|	HKCategoryValueSleepAnalysisInBed	|
 |	sleep.awake	|	AWAKE	|	HKCategoryValueSleepAnalysisAwake	|
 |	sleep.outOfBed	|	OUT_OF_BED	|	NA	|

--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -410,7 +410,10 @@ static NSString *const HKPluginKeyUUID = @"UUID";
       @"HKCategoryTypeIdentifierSleepAnalysis":@{
         @"HKCategoryValueSleepAnalysisInBed":@(HKCategoryValueSleepAnalysisInBed),
         @"HKCategoryValueSleepAnalysisAsleep":@(HKCategoryValueSleepAnalysisAsleep),
-        @"HKCategoryValueSleepAnalysisAwake":@(HKCategoryValueSleepAnalysisAwake)
+        @"HKCategoryValueSleepAnalysisAwake":@(HKCategoryValueSleepAnalysisAwake),
+        @"HKCategoryValueSleepAnalysisAsleepCore":@(HKCategoryValueSleepAnalysisAsleepCore),
+        @"HKCategoryValueSleepAnalysisAsleepDeep":@(HKCategoryValueSleepAnalysisAsleepDeep),
+        @"HKCategoryValueSleepAnalysisAsleepREM":@(HKCategoryValueSleepAnalysisAsleepREM)
       }
     };
 

--- a/www/ios/health.js
+++ b/www/ios/health.js
@@ -257,9 +257,27 @@ Health.prototype.query = function (opts, onSuccess, onError) {
             res.id = data[i].UUID
             res.startDate = new Date(data[i].startDate);
             res.endDate = new Date(data[i].endDate);
-            if (data[i].value == 0) res.value = 'sleep.inBed';
-            else if (data[i].value == 1) res.value = 'sleep';
-            else res.value = 'sleep.awake';
+            switch(data[i].value) {
+              case 0:
+                res.value = 'sleep.inBed';
+                break;
+              case 1:
+              default:
+                res.value = 'sleep';
+                break;
+              case 2:
+                res.value = 'sleep.awake';
+                break;
+              case 3:
+                res.value = 'sleep.light';
+                break;
+              case 4:
+                res.value = 'sleep.deep';
+                break;
+              case 5:
+                res.value = 'sleep.rem';
+                break;
+            }
             res.unit = 'activityType';
             res.sourceName = data[i].sourceName;
             res.sourceBundleId = data[i].sourceBundleId;


### PR DESCRIPTION
WatchOS 9 now also support core/light, deep and REM sleep. Currently these sleep states are mapped to sleep.awake, which seems not correct.