### PR TITLE
Make window.location.href available in privacypolicy.html

### DIFF
--- a/src/android/PermissionsRationaleActivity.java
+++ b/src/android/PermissionsRationaleActivity.java
@@ -3,7 +3,9 @@ package org.apache.cordova.health;
 import android.app.Activity;
 import android.os.Bundle;
 import android.util.Patterns;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
 public class PermissionsRationaleActivity extends Activity {
 
@@ -28,8 +30,15 @@ public class PermissionsRationaleActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         WebView myWebView = new WebView(getApplicationContext());
+        myWebView.setWebViewClient(new WebViewClient() {
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                return false;                
+            }
+        });
         setContentView(myWebView);
-
+        WebSettings webSettings = myWebView.getSettings();
+        webSettings.setJavaScriptEnabled(true);
         myWebView.loadUrl(PermissionsRationaleActivity.url);
     }
 }


### PR DESCRIPTION
setPrivacyPolicyURL() is provided, but If you perform a task kill, the app's permissions page will read privacypolicy.html  
If you want to put a privacy policy on a web page, you must specify the URL using Javascript.  

window.location.href = 'https://www.google.com/';