### PR TITLE
Corrected method for issue #351

### DIFF
--- a/src/ios/HealthKit.m
+++ b/src/ios/HealthKit.m
@@ -564,7 +564,7 @@ static NSString *const HKPluginKeyUUID = @"UUID";
         NSString* scheme = @"x-apple-health://";
         
         if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:scheme]]) {
-            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:scheme]];
+            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:scheme] options:@{} completionHandler:nil];
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:(true)];
         }
         else {


### PR DESCRIPTION
This should correct the issue #351 
On the simulator (IOS 18.2) the health app is opening correctly after this change. I couldn't test it on a real device though 